### PR TITLE
Enhance Moonshot CDD data downloader for simplified CSV variant generation

### DIFF
--- a/covid_moonshot_ml/datasets/moonshot.py
+++ b/covid_moonshot_ml/datasets/moonshot.py
@@ -4,23 +4,32 @@ import requests
 import sys
 import time
 
+# Handle logging
+import logging
+
 from .utils import get_achiral_molecules
 
-BASE_URL = 'https://app.collaborativedrug.com/api/v1/vaults/5549/'
+VAULT_URL = 'https://app.collaborativedrug.com/api/v1/vaults/5549/'
 ## All molecules with SMILES (public)
+# This string comes from accessing a saved CDD search and copying the trailing `searches/...` part of the URL
 ALL_SMI_SEARCH = 'searches/8975987-kmJ-vR0fhkdccPw5UdWiIA'
+NONCOVALENT_SMI_SEARCH = 'searches/9737468-RPSZ3XnVP-ufU6nNTJjZ_Q'
 
-def download_url(url, header):
+def download_url(search_url, header, timeout=5000, retry_delay=5):
     """
     Make requests to the API using the passed information.
 
     Parameters
     ----------
-    url : string
-        URL for the initial GET request
+    search_url : string
+        URL for the initial search GET request
     header : dict
         Header information passed to GET request. Must contain an entry for
         'X-CDD-token' that gives the user's CDD API token
+    timeout : float, optional, default=5000
+        Timeout (in seconds)
+    retry_delay : float, optional, default=5
+        Delay between retry status (in seconds)
 
     Returns
     -------
@@ -28,30 +37,41 @@ def download_url(url, header):
         Response object from the final export GET request
     """
     ## Make the initial download request
-    response = requests.get(url, headers=header)
+    logging.debug(f'download_url : initiating search {search_url}')
+    response = requests.get(search_url, headers=header)
+    logging.debug(f'  {response}')
     export_id = response.json()['id']
-    url = f'{BASE_URL}export_progress/{export_id}'
+    logging.debug(f'  Export id for requested search is {export_id}')
 
     ## Check every 5 seconds to see if the export is ready
+    status_url = f'{VAULT_URL}export_progress/{export_id}'
     status = None
     total_seconds = 0
-    while status != 'finished':
-        response = requests.get(url, headers=header)
+    while True:
+        logging.debug(f'  checking if export is finished at {status_url}')
+        response = requests.get(status_url, headers=header)
         status = response.json()['status']
 
-        time.sleep(5)
-        total_seconds += 5
-        ## Time out after 5000 seconds
-        if total_seconds > 5000:
-            print('Export Never Finished')
+        if (status == 'finished'):
+            logging.debug(f'  Export is ready')
+            break
+
+        # Sleep between retries
+        time.sleep(retry_delay)
+        total_seconds += retry_delay
+
+        # Check if we have reached the timeout
+        if total_seconds > timeout:
+            logging.error('Export Never Finished')
             break
 
     if status != 'finished':
-        sys.exit('EXPORT IS BROKEN')
+        logging.error('CDD Vault export timed out. Please check manually: {search_url}')
+        sys.exit('Export failed')
 
     ## Send GET request for final export
-    url = f'{BASE_URL}exports/{export_id}'
-    response = requests.get(url, headers=header)
+    result_url = f'{VAULT_URL}exports/{export_id}'
+    response = requests.get(result_url, headers=header)
 
     return(response)
 
@@ -73,7 +93,7 @@ def download_achiral(header, fn_out=None):
         DataFrame containing compound information for all achiral molecules
     """
     ## Download all molecules to start
-    response = download_url(BASE_URL+ALL_SMI_SEARCH, header)
+    response = download_url(VAULT_URL+NONCOVALENT_SMI_SEARCH, header)
     ## Parse into DF
     mol_df = pandas.read_csv(StringIO(response.content.decode()))
     ## Get rid of any molecules that snuck through without SMILES
@@ -93,3 +113,60 @@ def download_achiral(header, fn_out=None):
         achiral_df.to_csv(fn_out, index=False)
 
     return(achiral_df)
+
+# TODO: Generalize inclusion criteria to something more compact
+def download_molecules(header,
+                       smiles_fieldname='suspected_SMILES',
+                       fn_out=None,
+                       **filter_kwargs):
+    """
+    Download all molecules and remove any chiral molecules.
+
+    Parameters
+    ----------
+    header : dict
+        Header information passed to GET request. Must contain an entry for
+        'X-CDD-token' that gives the user's CDD API token
+    smiles_fieldname : str, optional, default='suspected_SMILES'
+        Field to use to extract SMILES
+    fn_out : str, optional, default=None
+        If specified, filename to write CSV to
+    filter_kwargs : 
+        Other arguments passed to filter_molecules
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing compound information for all achiral molecules
+    """
+    ## DEBUG : use local copy if present
+    import os
+    if os.path.exists('download.csv'):
+        with open('download.csv', 'rt') as infile:
+            content = infile.read()
+    else:    
+        ## Download all molecules to start
+        url = VAULT_URL+NONCOVALENT_SMI_SEARCH
+        logging.debug(f'Downloading data from CDD vault from {url}')
+        response = download_url(url, header)
+        content = response.content.decode()
+
+        # DEBUG
+        with open('download.csv', 'wt') as outfile:
+            outfile.write(content)
+
+    ## Parse into DF
+    mol_df = pandas.read_csv(StringIO(content))
+    logging.debug(f'\n{mol_df}')
+
+    ## Remove chiral molecules
+    logging.debug(f'Filtering dataframe...')
+    from .utils import filter_molecules_dataframe
+    filtered_df = filter_molecules_dataframe(mol_df, **filter_kwargs)
+
+    ## Save to CSV as requested
+    if fn_out:
+        logging.debug(f'Generating CSV file {fn_out}')
+        filtered_df.to_csv(fn_out, index=False)
+
+    return(filtered_df)

--- a/covid_moonshot_ml/datasets/utils.py
+++ b/covid_moonshot_ml/datasets/utils.py
@@ -2,6 +2,7 @@ import json
 import pandas
 from rdkit.Chem import CanonSmiles, FindMolChiralCenters, MolFromSmiles
 import re
+import logging
 
 from ..schema import ExperimentalCompoundData, ExperimentalCompoundDataUpdate, \
     EnantiomerPair, EnantiomerPairList
@@ -271,3 +272,118 @@ def get_achiral_molecules(mol_df):
             raise ValueError(f'No SMILES found for {r["Canonical PostEra ID"]}')
 
     return(mol_df.loc[achiral_idx,:])
+
+def filter_molecules_dataframe(
+        mol_df,
+        smiles_fieldname='suspected_SMILES',
+        retain_achiral=False,
+        retain_racemic=False,
+        retain_enantiopure=False,
+        retain_semiquantitative_data=False,
+    ):
+    """
+    Filter a dataframe of molecules to retain those specified.
+
+    Parameters
+    ----------
+    mol_df : pandas.DataFrame
+        DataFrame containing compound information
+    smiles_fieldname : str, optional, default='suspected_SMILES'
+        Field name to use for reference SMILES
+    retain_achrial : bool, optional, default=False
+        If True, retain achiral measurements
+    retain_racemic : bool, optional, default=False
+        If True, retain racemic measurements
+    retain_enantiopure : bool, optional, default=False
+        If True, retain chrially resolved measurements
+    retain_out_of_range_data : bool, optional, default=False
+        If True, retain semiquantitative data (data outside assay dynamic range)
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing compound information for all achiral molecules
+
+    """
+    # Define functions to evaluate whether molecule is achiral, racemic, or resolved
+    is_achiral = lambda smi: len(FindMolChiralCenters(MolFromSmiles(smi),
+        includeUnassigned=True, includeCIP=False,
+        useLegacyImplementation=False)) == 0
+    is_racemic = lambda smi: (len(FindMolChiralCenters(MolFromSmiles(smi),
+        includeUnassigned=True, includeCIP=False,
+        useLegacyImplementation=False)) - len(FindMolChiralCenters(MolFromSmiles(smi),
+            includeUnassigned=False, includeCIP=False,
+            useLegacyImplementation=False))) > 0
+    is_enantiopure = lambda smi: (not is_achiral(smi)) and (not is_racemic(smi))
+
+    # Re-label SMILES field and change name of PostEra ID field
+    mol_df = mol_df.rename(columns={smiles_fieldname : 'smiles', 'Canonical PostEra ID' : 'name'})
+
+    logging.debug('Filtering molecules dataframe')
+    # Get rid of any molecules that snuck through without SMILES field specified
+    logging.debug(f'  dataframe contains {mol_df.shape} entries')
+    idx = mol_df.loc[:,'smiles'].isna()
+    mol_df = mol_df.loc[~idx,:].copy()
+    logging.debug(f'  dataframe contains {mol_df.shape} entries after removing molecules with unspecified {smiles_fieldname} field')
+    # Convert CXSMILES to SMILES by removing extra info
+    mol_df.loc[:,'smiles'] = [s.strip('|').split()[0] for s in mol_df.loc[:,'smiles']]
+
+    # Determine which molecules will be retained
+    include_flags = []
+    for _, row in mol_df.iterrows():
+        smiles = row['smiles']
+        include_this_molecule = (retain_achiral and is_achiral(smiles)) or (retain_racemic and is_racemic(smiles)) or (retain_enantiopure and is_enantiopure(smiles))
+        include_flags.append(include_this_molecule)
+    mol_df = mol_df.loc[include_flags,:]
+
+    # Filter out semiquantitative data, if requested
+    if not retain_semiquantitative_data:
+        include_flags = []
+        for _, row in mol_df.iterrows():
+            try:
+                _ = float(row['ProteaseAssay_Fluorescence_Dose-Response_Weizmann: IC50 (µM)'])
+                include_flags.append(True)
+            except ValueError as e:
+                include_flags.append(False)
+        mol_df = mol_df.loc[include_flags,:]
+        logging.debug(f'  dataframe contains {mol_df.shape} entries after removing semiquantitative data')
+
+    # Compute pIC50s and uncertainties from 95% CIs
+    # TODO: In future, we can provide CIs as well
+    import numpy as np
+    import sigfig
+    pIC50_series = []
+    pIC50_stderr_series = []
+    for _, row in mol_df.iterrows():
+        pIC50 = row['ProteaseAssay_Fluorescence_Dose-Response_Weizmann: Avg pIC50'] # string
+        try:
+            IC50 = float(row['ProteaseAssay_Fluorescence_Dose-Response_Weizmann: IC50 (µM)']) * 1e-6 # molar
+            IC50_lower = float(row['ProteaseAssay_Fluorescence_Dose-Response_Weizmann: IC50 CI (Lower) (µM)']) * 1e-6 # molar
+            IC50_upper = float(row['ProteaseAssay_Fluorescence_Dose-Response_Weizmann: IC50 CI (Upper) (µM)']) * 1e-6 # molar
+            
+            pIC50 = -np.log10(IC50)
+            pIC50_stderr = np.abs(-np.log10(IC50_lower) + np.log10(IC50_upper)) / 4.0 # assume normal distribution
+
+            # Render into string with appropriate sig figs
+            pIC50, pIC50_stderr = sigfig.round(pIC50, uncertainty=pIC50_stderr, sep=tuple) # strings
+
+        except ValueError:
+            # Could not convert to string because value was semiquantitative
+            if row['ProteaseAssay_Fluorescence_Dose-Response_Weizmann: IC50 (µM)'] == '(IC50 could not be calculated)':
+                pIC50 = '< 4.0' # lower limit of detection
+
+            # Keep pIC50 string
+            # Use default pIC50 error
+            print(row)
+            pIC50, pIC50_stderr = pIC50, '0.5' # strings
+
+        pIC50_series.append(pIC50)
+        pIC50_stderr_series.append(pIC50_stderr)
+    
+    mol_df['pIC50'] = pIC50_series
+    mol_df['pIC50_stderr'] = pIC50_stderr_series
+
+    # Retain only fields we need
+    mol_df = mol_df.filter(['smiles', 'name', 'pIC50', 'pIC50_stderr'])
+    logging.debug(f'\n{mol_df}')
+    
+    return mol_df

--- a/covid_moonshot_ml/nn/__init__.py
+++ b/covid_moonshot_ml/nn/__init__.py
@@ -1,1 +1,2 @@
-from .models import *
+# Avoid importing everything by default to avoid need to have all prerequsites installed even if they are not needed.
+#from .models import *

--- a/devtools/conda-envs/moonshot_ml.yaml
+++ b/devtools/conda-envs/moonshot_ml.yaml
@@ -1,4 +1,4 @@
-name: test
+name: moonshotml
 channels:
   - pytorch
   - pyg
@@ -27,6 +27,7 @@ dependencies:
 
   # Pip-only installs
   - pip:
+    - sigfig
     - e3nn
     - biopython
     - ase

--- a/scripts/download_moonshot_data.py
+++ b/scripts/download_moonshot_data.py
@@ -1,16 +1,32 @@
+"""
+Download Moonshot data
+
+"""
+
 import argparse
 import os
 import sys
 
+import logging
+#logging.basicConfig(filename='example.log', encoding='utf-8', level=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG)
+
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-from covid_moonshot_ml.datasets.moonshot import download_achiral
+from covid_moonshot_ml.datasets.moonshot import download_molecules
 
 ################################################################################
 def get_args():
+    # TODO: Update to more modern, full-featured command-line
+    # e.g. click : https://click.palletsprojects.com/
     parser = argparse.ArgumentParser(description='')
 
+    # TODO: Enable token to be specified by environment variable
     parser.add_argument('-tok', required=True,
         help='File containing CDD token.')
+
+    # TODO: Include options for specifying which subsets to include (achiral, racemic, enantiopure)
+    # TODO: Include option for specifying which SMILES field to use
+
     parser.add_argument('-o', required=True, help='Output CSV file.')
 
     return(parser.parse_args())
@@ -19,7 +35,8 @@ def main():
     args = get_args()
 
     header = {'X-CDD-token': ''.join(open(args.tok, 'r').readlines()).strip()}
-    _ = download_achiral(header, fn_out=args.o)
+    #_ = download_achiral(header, fn_out=args.o)
+    _ = download_molecules(header, smiles_fieldname='suspected_SMILES', retain_achiral=True, retain_racemic=True, fn_out=args.o)
 
 if __name__ == '__main__':
     main()

--- a/scripts/train_dd.py
+++ b/scripts/train_dd.py
@@ -7,12 +7,12 @@ import os
 import pickle as pkl
 import re
 import torch
-from torch_geometric.nn import SchNet
+from torch_geometric.nn.models import SchNet
 from torch_geometric.datasets import QM9
 
 
 from covid_moonshot_ml.data.dataset import DockedDataset
-from covid_moonshot_ml.nn import E3NNBind, SchNetBind
+from covid_moonshot_ml.nn.models import E3NNBind, SchNetBind
 from covid_moonshot_ml.schema import ExperimentalCompoundDataUpdate
 from covid_moonshot_ml.utils import calc_e3nn_model_info, find_most_recent, \
     train, plot_loss


### PR DESCRIPTION
## Description
When complete, this PR will enhance the Moonshot CDD data downloader to also provide a simplified CSV file generator that will allow us to archive curated Moonshot data for use in machine learning experiments.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Generate [achiral + racemic simplified test CSV](https://gist.githubusercontent.com/jchodera/89776c939793b8da98ac3d6dc9226dc2/raw/7256a047a5fe69fcbac04aba9aa7b37959964fbd/achiral-racemic.csv)
  - [ ] Ensure that JSON retrieval still works
  - [ ] Update CLI to use `click` and produce sensible default output

## Status
- [ ] Ready to go