### PR TITLE
Add smiles docking output

### DIFF
--- a/asapdiscovery/docking/docking.py
+++ b/asapdiscovery/docking/docking.py
@@ -250,7 +250,7 @@ def run_docking_oe(
     )
     oechem.OESetSDData(posed_mol, f"Docking_{docking_id}_clash", str(clash))
     oechem.OESetSDData(posed_mol, f"SMILES", oechem.OEMolToSmiles(dock_lig))
-    print(f"############ SETTING SMILES {oechem.OEMolToSmiles(dock_lig)} for LIG {posed_mol}")
+
     ## Set molecule name if given
     if compound_name:
         posed_mol.SetTitle(compound_name)

--- a/asapdiscovery/docking/docking.py
+++ b/asapdiscovery/docking/docking.py
@@ -249,7 +249,8 @@ def run_docking_oe(
         posed_mol, f"Docking_{docking_id}_Chemgauss4", str(chemgauss_score)
     )
     oechem.OESetSDData(posed_mol, f"Docking_{docking_id}_clash", str(clash))
-
+    oechem.OESetSDData(posed_mol, f"SMILES", oechem.OEMolToSmiles(dock_lig))
+    print(f"############ SETTING SMILES {oechem.OEMolToSmiles(dock_lig)} for LIG {posed_mol}")
     ## Set molecule name if given
     if compound_name:
         posed_mol.SetTitle(compound_name)

--- a/asapdiscovery/docking/scripts/run_docking_oe.py
+++ b/asapdiscovery/docking/scripts/run_docking_oe.py
@@ -158,12 +158,14 @@ def mp_func(out_dir, lig_name, du_name, *args, **kwargs):
         clash = int(
             oechem.OEGetSDData(posed_mol, f"Docking_{docking_id}_clash")
         )
+        smiles = oechem.OEGetSDData(posed_mol, f"SMILES")
     else:
         out_fn = ""
         rmsd = -1.0
         posit_prob = -1.0
         chemgauss_score = -1.0
         clash = -1
+        smiles = "None"
 
     results = (
         lig_name,
@@ -173,6 +175,7 @@ def mp_func(out_dir, lig_name, du_name, *args, **kwargs):
         posit_prob,
         chemgauss_score,
         clash,
+        smiles
     )
     pkl.dump(results, open(os.path.join(out_dir, "results.pkl"), "wb"))
     return results
@@ -364,6 +367,7 @@ def main():
         "POSIT_prob",
         "chemgauss4_score",
         "clash",
+        "SMILES"
     ]
     nprocs = min(mp.cpu_count(), len(mp_args), args.num_cores)
     print(f"Running {len(mp_args)} docking runs over {nprocs} cores.")


### PR DESCRIPTION
## Description
Implements SMILES entries into docking outputs as previously done by @kaminow, I think this was lost during the recent refactor. Having SMILES is very helpful downstream during processing of docking results.

## ToDo
- [x] add SMILES to SDF file output under "SMILES"
- [x] add SMILES to pickle output for later retrieval by docking analysis scripts

## Status
- [x] Ready to go