### PR TITLE
Remove extra ligands

### DIFF
--- a/asapdiscovery/docking/modeling.py
+++ b/asapdiscovery/docking/modeling.py
@@ -573,3 +573,46 @@ def build_dimer_from_monomer(prot):
 
     print(all_chain_ids)
     return prot
+
+
+def remove_extra_ligands(mol, lig_chain=None):
+    """
+    Remove extra ligands from a molecule. Useful in the case where a complex
+    crystal structure has two copies of the ligand, but we only want one. If
+    `lig_chain` is not specified, we'll automatically select the first chain
+    (as sorted alphabetically) to be the copy to keep.
+
+    Creates a copy of the input molecule, so input molecule is not modified.
+
+    Parameters
+    ----------
+    mol : oechem.OEMolBase
+        Complex molecule.
+    lig_chain : str, optional
+        Ligand chain ID to keep.
+
+    Returns
+    -------
+    oechem.OEMolBase
+        Molecule with extra ligand copies removed.
+    """
+    ## Atom filter to match all atoms in residue with name LIG
+    all_lig_match = oechem.OEAtomMatchResidueID()
+    all_lig_match.SetName("LIG")
+    all_lig_filter = oechem.OEAtomMatchResidue(all_lig_match)
+
+    ## Detect ligand chain to keep if none is given
+    if lig_chain is None:
+        lig_chain = sorted(
+            {
+                oechem.OEAtomGetResidue(a).GetExtChainID()
+                for a in mol.GetAtoms(all_lig_filter)
+            }
+        )[0]
+
+    ## Copy molecule and delete all lig atoms that don't have the desired chain
+    mol_copy = mol.CreateCopy()
+    for a in mol_copy.GetAtoms(all_lig_filter):
+        if oechem.OEAtomGetResidue(a).GetExtChainID() != lig_chain:
+            mol_copy.DeleteAtom(a)
+    return mol_copy

--- a/asapdiscovery/docking/modeling.py
+++ b/asapdiscovery/docking/modeling.py
@@ -1,6 +1,6 @@
 from openeye import oechem, oedocking, oespruce
 
-from asapdiscovery.data.utils import (
+from asapdiscovery.data.openeye import (
     load_openeye_pdb,
     load_openeye_sdf,
     split_openeye_mol,

--- a/asapdiscovery/docking/scripts/prep_proteins.py
+++ b/asapdiscovery/docking/scripts/prep_proteins.py
@@ -28,6 +28,7 @@ from asapdiscovery.docking.modeling import (
     prep_receptor,
     du_to_complex,
     mutate_residues,
+    remove_extra_ligands,
 )
 from asapdiscovery.data import pdb
 from asapdiscovery.data.utils import edit_pdb_file, seqres_to_res_list
@@ -121,6 +122,11 @@ def prep_mp(
         initial_prot = mutate_residues(
             initial_prot, res_list, xtal.protein_chains
         )
+
+    ## Delete extra copies of ligand in the complex
+    initial_prot = remove_extra_ligands(
+        initial_prot, lig_chain=xtal.active_site_chain
+    )
 
     if ref_prot:
         print("Aligning receptor")

--- a/cluster_scripts/prep_full_mpro.sh
+++ b/cluster_scripts/prep_full_mpro.sh
@@ -1,0 +1,19 @@
+
+#!/bin/bash
+#BSUB -J prep_full_mpro
+#BSUB -R span[hosts=1]
+#BSUB -oo log_files/prep_full_mpro.out
+#BSUB -cwd /lila/data/chodera/kaminowb/stereochemistry_pred/mers
+#BSUB -n 32
+#BSUB -R rusage[mem=4]
+#BSUB -W 24:00
+mkdir -p /lila/data/chodera/kaminowb/stereochemistry_pred/mers//asap-datasets//full_frag_prepped_mpro_12_2022/
+PYTHONPATH=${PYTHONPATH}:$(readlink -f /lila/data/chodera/kaminowb/stereochemistry_pred/mers//covid-moonshot-ml/) \
+python /lila/data/chodera/kaminowb/stereochemistry_pred/mers//covid-moonshot-ml//asapdiscovery/docking/scripts//prep_proteins.py \
+-d /lila/data/chodera/kaminowb/stereochemistry_pred/mers//asap-datasets//mpro_fragalysis_2022_10_12//aligned/ \
+-x /lila/data/chodera/kaminowb/stereochemistry_pred/mers//asap-datasets//mpro_fragalysis_2022_10_12//extra_files/Mpro_compound_tracker_csv.csv \
+-o /lila/data/chodera/kaminowb/stereochemistry_pred/mers//asap-datasets//full_frag_prepped_mpro_12_2022/ \
+-l /lila/home/kaminowb/.openeye/rcsb_spruce.loop_db \
+-n 32 \
+-s /lila/data/chodera/kaminowb/stereochemistry_pred/mers//covid-moonshot-ml//metadata/mpro_sars2_seqres.yaml
+echo done


### PR DESCRIPTION
## Description
We've had a hard time tracking down when OpenEye grabs the ligand from chain A vs chain B to use to create the receptor grid. In order to do this explicitly, @kaminow has written a function to first remove the ligand from the chain we don't need.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] remove ligands from chains that aren't in `xtal.active_site_chain`
  - [x] confirm that resulting docked poses are aligned with the ligands aligned to each other

## Questions

## Status
- [x] Ready to go