### PR TITLE
take SMILES of last conformer instead of taking list of SMILES

### DIFF
--- a/asapdiscovery/docking/scripts/run_docking_oe.py
+++ b/asapdiscovery/docking/scripts/run_docking_oe.py
@@ -148,7 +148,7 @@ def mp_func(out_dir, lig_name, du_name, *args, **kwargs):
         posit_probs = []
         posit_methods = []
         chemgauss_scores = []
-        smiles = []
+
         for conf in posed_mol.GetConfs():
             rmsds.append(
                 float(oechem.OEGetSDData(conf, f"Docking_{docking_id}_RMSD"))
@@ -164,7 +164,7 @@ def mp_func(out_dir, lig_name, du_name, *args, **kwargs):
                     oechem.OEGetSDData(conf, f"Docking_{docking_id}_Chemgauss4")
                 )
             )
-            smiles.append(oechem.OEGetSDData(posed_mol, f"SMILES"))
+        smiles = oechem.OEGetSDData(conf, f"SMILES")
         clash = int(oechem.OEGetSDData(conf, f"Docking_{docking_id}_clash"))
     else:
         out_fn = ""
@@ -186,10 +186,10 @@ def mp_func(out_dir, lig_name, du_name, *args, **kwargs):
             method,
             chemgauss,
             clash,
-            smi,
+            smiles,
         )
-        for i, (rmsd, prob, method, chemgauss, smi) in enumerate(
-            zip(rmsds, posit_probs, posit_methods, chemgauss_scores, smiles)
+        for i, (rmsd, prob, method, chemgauss) in enumerate(
+            zip(rmsds, posit_probs, posit_methods, chemgauss_scores)
         )
     ]
 


### PR DESCRIPTION
## Description
In `run_docking_oe.py`, SMILES strings were not written to `results_df` correctly, resulting in empty fields in the pickled output files. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] fix SMILES field output in pickled docking outputs. (instead of iterating over conformers and appending SMILES to a list, just take the SMILES of the last conformer)

## Status
- [x] Ready to go