### PR TITLE
add quick test to check if user has correctly pointed to prepped structures

### DIFF
--- a/asapdiscovery/docking/scripts/run_docking_oe.py
+++ b/asapdiscovery/docking/scripts/run_docking_oe.py
@@ -88,6 +88,12 @@ def load_dus(file_base, by_compound=False):
         ]
     else:
         all_fns = glob(file_base)
+    
+    # check that we actually have loaded in prepped receptors.
+    if len(all_fns) == 0:
+        raise ValueError(
+            f"No prepared receptors found in {file_base}, check that the path is correct."
+        )
 
     du_dict = {}
     dataset_dict = {}


### PR DESCRIPTION
## Description
While running `run_docking_oe.py` with the CLI flag `-r` there are currently no tests to check whether the user has correctly pointed to the folder with prepped receptors. This quick check informs the user in case `glob` finds no paths to receptor files.

This is a useful check because in the current state of the code an error is thrown *way* [downstream](https://github.com/choderalab/covid-moonshot-ml/blob/main/asapdiscovery/docking/scripts/run_docking_oe.py#L391) and it takes a while to trace back the error manually. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] implement test

## Questions
- [x] Not really a question but it would be good to have similar quick tests for other flags in the CLI.

## Status
- [x] Ready to go